### PR TITLE
Hotfix for onChange event

### DIFF
--- a/admin/src/components/Wysiwyg/index.js
+++ b/admin/src/components/Wysiwyg/index.js
@@ -57,8 +57,7 @@ Wysiwyg.defaultProps = {
   disabled: false,
   error: undefined,
   intlLabel: '',
-  required: false,
-  value: '',
+  required: false
 };
 
 Wysiwyg.propTypes = {

--- a/admin/src/components/editorjs/index.js
+++ b/admin/src/components/editorjs/index.js
@@ -50,10 +50,10 @@ const Editor = ({ onChange, name, value }) => {
             }
             document.querySelector('[data-tool="image"]').remove()
           }}
-          onChange={(api, newData) => {
-            if (newData.blocks.length) {
-              onChange({target: {name, value: JSON.stringify(newData)}});
-            }
+          onChange={(api) => {
+            api.saver.save().then((res) => {
+              onChange({target: {name, value: JSON.stringify(res)}});
+            });
           }}
           tools={{...requiredTools, ...customTools, ...customImageTool}}
           instanceRef={instance => setEditorInstance(instance)}


### PR DESCRIPTION
I noticed issues with the `onChange` event not always being updated towards strapi, now it does and allows empty blocks, pasting blocks from other windows, ctrl+a and backspace.

My IDE was flagging up `value` twice in the WYSIWYG properties so I have omitted the second declaration made