### PR TITLE
Fix bug missing some attributes on image component

### DIFF
--- a/admin/src/components/medialib/component.js
+++ b/admin/src/components/medialib/component.js
@@ -17,13 +17,17 @@ const MediaLibComponent = ({isOpen, onChange, onToggle}) => {
 
   const handleSelectAssets = files => {
     const formattedFiles = files.map(f => ({
-      alt: f.alternativeText || f.name,
       url: prefixFileUrlWithBackendUrl(f.url),
+      alternativeText: f.alternativeText,
+      name: f.name,
       width: f.width,
       height: f.height,
       size: f.size,
       mime: f.mime,
-      formats: f.formats
+      formats: f.formats,
+      ext: f.ext,
+      previewUrl: f.previewUrl,
+      provider_metadata: f.provider_metadata
     }));
     onChange(formattedFiles);
   };

--- a/admin/src/components/medialib/utils.js
+++ b/admin/src/components/medialib/utils.js
@@ -20,12 +20,16 @@ export const changeFunc = ({indexStateSetter, editor, data, index}) => {
     const newBlockData = {
       file: {
         url: entry.url.replace(window.location.origin, ""),
-        mime: entry.mime,
+        alternativeText: entry.alternativeText,
+        name: entry.name,
         height: entry.height,
         width: entry.width,
         size: entry.size,
-        alt: entry.alt,
+        mime: entry.mime,
         formats: entry.formats,
+        ext: entry.ext,
+        previewUrl: entry.previewUrl,
+        provider_metadata: entry.provider_metadata
       },
       caption: "",
       withBorder: false,


### PR DESCRIPTION
As I think the image block shoulds contain the original Strapi image information such as `alternativeText`, `name`, `ext`, `provider_metadata` ... instead of removing or customizing it. So it keeps the consistent with other plugins that may use them.